### PR TITLE
Add `TArray::Resize()` and fix `TArray::Reserve()`

### DIFF
--- a/Core/Memory/Containers/TArray.h
+++ b/Core/Memory/Containers/TArray.h
@@ -23,7 +23,8 @@ public:
 
 	uint32 Length() const;
 	uint32 Capacity() const;
-	void Resize(uint32 newCapacity);
+	void Resize(uint32 newLength);
+	void Reserve(uint32 newCapacity);
 
 	T& operator [](uint32 i);
 	const T& operator [](uint32 i) const;
@@ -158,14 +159,17 @@ uint32 TArray<T>::Capacity() const
 }
 
 template <typename T>
-void TArray<T>::Resize(uint32 newCapacity)
+void TArray<T>::Resize(uint32 newLength)
 {
-	if (array)
-		array = (T*)alloc->Reallocate(array, newCapacity * sizeof(T));
-	else
-		array = (T*)alloc->Allocate(newCapacity * sizeof(T), alignof(T));
+	EnsureCapacity(newLength);
+	length = newLength;
+}
 
-	capacity = newCapacity;
+template <typename T>
+void TArray<T>::Reserve(uint32 newCapacity)
+{
+	if (!EnsureCapacity(newCapacity))
+		throw std::runtime_error("Failed to reserve array capacity");
 }
 
 template <typename T>
@@ -222,8 +226,14 @@ bool TArray<T>::EnsureCapacity(uint32 requiredCapacity)
 		return false;
 
 	uint32 exponentiallyIncreasedSize = (uint32)((float)(capacity == 0 ? 4 : capacity) * 1.5f);
+	uint32 newCapacity = requiredCapacity <= exponentiallyIncreasedSize ? exponentiallyIncreasedSize : requiredCapacity;
 
-	Resize(requiredCapacity <= exponentiallyIncreasedSize ? exponentiallyIncreasedSize : requiredCapacity);
+	if (array)
+		array = (T*)alloc->Reallocate(array, newCapacity * sizeof(T));
+	else
+		array = (T*)alloc->Allocate(newCapacity * sizeof(T), alignof(T));
+
+	capacity = newCapacity;
 
 	return true;
 }

--- a/Core/Tests/Core.Tests/Memory/Containers/TArrayTests.cpp
+++ b/Core/Tests/Core.Tests/Memory/Containers/TArrayTests.cpp
@@ -219,3 +219,28 @@ TEST(TArrayTests, AttachWithAlloc)
 	EXPECT_EQ(64, a[5]);
 	EXPECT_EQ(128, a[6]);
 }
+
+TEST(TArrayTests, Resize)
+{
+	TArray<uint32> a;
+
+	EXPECT_EQ(0, a.Length());
+
+	a.Resize(4);
+
+	EXPECT_EQ(4, a.Length());
+	EXPECT_LE((uint32)4, a.Capacity());
+}
+
+TEST(TArrayTests, Reserve)
+{
+	TArray<uint32> a;
+
+	EXPECT_EQ(0, a.Length());
+	EXPECT_EQ(0, a.Capacity());
+
+	a.Reserve(4);
+
+	EXPECT_EQ(0, a.Length());
+	EXPECT_LE((uint32)4, a.Capacity());
+}


### PR DESCRIPTION
- Make `TArray::Resize()` work as a resizing.
- Add `TArray::Reserve()` which should work as `Resize()` currently
  works.
- Add simple tests for both of the previously mentioned functions.

Closes #39.